### PR TITLE
Create CrashLoopBackOff-Notes.md

### DIFF
--- a/CrashLoopBackOff-Notes.md
+++ b/CrashLoopBackOff-Notes.md
@@ -1,0 +1,3 @@
+I have sent my PR in to falco for the Init:CrashLoopBackOff error while implementing falco in minikube from the Falco - Runtime security monitoring & detection sceniario.
+
+Please look into it.


### PR DESCRIPTION
I have sent my PR in to falco for the Init:CrashLoopBackOff error while implementing falco in minikube from the Falco - Runtime security monitoring & detection sceniario.

Please look into it.